### PR TITLE
Add FastAPI scan endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ pip install -r requirements.txt
 python main.py --target example.com
 ```
 
+## APIサーバの起動
+
+FastAPI を利用した API サーバを起動します。
+
+```bash
+uvicorn yourtool.api:app --host 127.0.0.1 --port 8787
+```
+
 ## 開発手順
 
 ### 依存関係のインストール

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/src/yourtool/__init__.py
+++ b/src/yourtool/__init__.py
@@ -1,0 +1,3 @@
+"""YourTool package initialization."""
+
+__all__ = []

--- a/src/yourtool/api.py
+++ b/src/yourtool/api.py
@@ -1,0 +1,32 @@
+"""FastAPI application exposing scanning functionality."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from . import core
+
+app = FastAPI()
+
+
+class ScanRequest(BaseModel):
+    """Request model for the scan endpoint."""
+
+    target: str
+
+
+@app.post("/scan")
+async def scan(request: ScanRequest):
+    """Run a scan for the given target and return the result.
+
+    Parameters
+    ----------
+    request: ScanRequest
+        Incoming request containing the target to scan.
+
+    Returns
+    -------
+    dict
+        JSON serializable result produced by :func:`core.run_scan`.
+    """
+
+    return core.run_scan(request.target)


### PR DESCRIPTION
## Summary
- expose core.run_scan via FastAPI POST /scan endpoint
- document uvicorn startup on 127.0.0.1:8787
- add FastAPI and uvicorn dependencies

## Testing
- `python -m py_compile src/yourtool/api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c14264b5a88323ba5539f15016df9e