### PR TITLE
Add yourtool CLI and help test

### DIFF
--- a/src/yourtool/cli.py
+++ b/src/yourtool/cli.py
@@ -1,0 +1,36 @@
+import argparse
+import json
+from importlib import metadata
+
+from .core import run_scan
+
+
+def get_version() -> str:
+    """Return package version or a default."""
+    try:
+        return metadata.version("yourtool")
+    except metadata.PackageNotFoundError:
+        return "0.1.0"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="yourtool")
+    parser.add_argument("--version", action="version", version=get_version())
+    subparsers = parser.add_subparsers(dest="command")
+
+    scan_parser = subparsers.add_parser("scan", help="Run scan")
+    scan_parser.add_argument("--target", required=True, help="Target to scan")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "scan":
+        result = run_scan(args.target)
+        print(json.dumps(result))
+        return 0
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_help_exits_zero():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "yourtool.cli", "--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        cwd=repo_root,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add argparse-based CLI with --version and scan command
- run core.run_scan from CLI and output JSON
- test that CLI --help exits successfully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36d8974908323a3cb418269e526f6