### PR TITLE
Add FastAPI scan endpoint and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ pip install -r requirements.txt
 python main.py --target example.com
 ```
 
+## APIサーバーの起動
+
+```bash
+uvicorn yourtool.api:app --host 127.0.0.1 --port 8787
+```
+
 ## 開発手順
 
 ### 依存関係のインストール

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/src/yourtool/api.py
+++ b/src/yourtool/api.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .core import run_scan
+
+
+class ScanRequest(BaseModel):
+    target: str
+
+
+app = FastAPI()
+
+
+@app.post("/scan")
+def scan_endpoint(request: ScanRequest) -> dict:
+    """Run a scan on the provided target."""
+    return run_scan(request.target)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient
+from yourtool.api import app
+
+
+def test_scan_endpoint_returns_json():
+    client = TestClient(app)
+    response = client.post("/scan", json={"target": "example.com"})
+    assert response.status_code == 200
+    assert response.json()["target"] == "example.com"


### PR DESCRIPTION
## Summary
- add FastAPI POST /scan endpoint returning `run_scan` output
- document uvicorn startup command
- record FastAPI dependencies and test API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c36ee2c4f88323bdb6f5ea0dd98a70