### PR TITLE
feat: print scan result as JSON

### DIFF
--- a/src/yourtool/cli.py
+++ b/src/yourtool/cli.py
@@ -24,8 +24,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "scan":
+        # run_scan returns a JSON-serialisable dict describing the scan
         result = run_scan(args.target)
-        print(json.dumps(result))
+        # ensure_ascii=False keeps non-ASCII targets readable in output
+        print(json.dumps(result, ensure_ascii=False))
         return 0
 
     parser.print_help()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,4 @@ def test_cli_help_exits_zero():
         cwd=repo_root,
     )
     assert result.returncode == 0
+    assert b"usage: yourtool" in result.stdout


### PR DESCRIPTION
## Summary
- enhance CLI scan command to output JSON with non-ASCII characters intact
- verify CLI help shows usage in test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c396194d548323aa0afbf41aeb9a40