### PR TITLE
feat: add scan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ python main.py --target example.com
 uvicorn yourtool.api:app --host 127.0.0.1 --port 8787
 ```
 
+### エンドポイント
+
+- `POST /scan`
+  - リクエスト: `{"target": "example.com"}`
+  - レスポンス: `{"status": "ok", "target": "example.com"}`
+
 ## 開発手順
 
 ### 依存関係のインストール

--- a/src/yourtool/api.py
+++ b/src/yourtool/api.py
@@ -1,17 +1,37 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .core import run_scan
 
 
 class ScanRequest(BaseModel):
+    """Request body for scan endpoint."""
+
+    target: str
+
+
+class ScanResult(BaseModel):
+    """Result of a scan operation."""
+
+    status: str
     target: str
 
 
 app = FastAPI()
 
+# Enable CORS for local development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost", "http://127.0.0.1"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
-@app.post("/scan")
-def scan_endpoint(request: ScanRequest) -> dict:
+
+@app.post("/scan", response_model=ScanResult)
+def scan_endpoint(request: ScanRequest) -> ScanResult:
     """Run a scan on the provided target."""
-    return run_scan(request.target)
+    result = run_scan(request.target)
+    return ScanResult(**result)


### PR DESCRIPTION
## Summary
- implement `/scan` endpoint returning typed result
- enable localhost CORS
- document API startup and endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3973aebbc832398ffdd7a27aef49b