### PR TITLE
chore: add CI workflows

### DIFF
--- a/.github/workflows/ci-hard.yml
+++ b/.github/workflows/ci-hard.yml
@@ -1,0 +1,28 @@
+name: CI Hard
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt flake8 pytest-cov
+      - name: Lint
+        run: flake8 src tests --max-line-length=120 --extend-ignore=E402
+      - name: Test with coverage
+        run: pytest --cov=src --cov-report=xml --cov-report=term --cov-fail-under=70
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/.github/workflows/ci-soft.yml
+++ b/.github/workflows/ci-soft.yml
@@ -1,0 +1,24 @@
+name: CI Soft
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt flake8 pytest-cov
+      - name: Lint
+        run: flake8 src tests --max-line-length=120 --extend-ignore=E402
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NWCD2
+[![CI](https://github.com/viiiviii538/NWCD2/actions/workflows/ci-hard.yml/badge.svg?branch=main)](https://github.com/viiiviii538/NWCD2/actions/workflows/ci-hard.yml)
 
 ネットワークのセキュリティ状況をチェックするツールです。簡単なコマンドで脆弱性や設定ミスを確認できます。
 


### PR DESCRIPTION
## Summary
- add soft CI for PRs and non-main pushes
- enforce tests, lint, and coverage on main branch
- display CI status badge in README

## Testing
- `flake8 src tests --max-line-length=120 --extend-ignore=E402`
- `pytest --cov=src --cov-report=term --cov-fail-under=70`


------
https://chatgpt.com/codex/tasks/task_e_68c399adfd188323a2f3ff98b847f61e